### PR TITLE
Updated checked url when intercepting /api/v2/resources

### DIFF
--- a/mpv-shim-local-connection-for-plex/mpv-shim-local-connection.js
+++ b/mpv-shim-local-connection-for-plex/mpv-shim-local-connection.js
@@ -187,7 +187,7 @@ function main () {
             xml.children[0].appendChild(s);
             inject = false;
             return serializer.serializeToString(xml);
-        } else if (parsedURL.pathname == "/api/v2/resources" && parsedURL.hostname == "plex.tv" && inject) {
+        } else if (parsedURL.pathname == "/api/v2/resources" && parsedURL.hostname == "clients.plex.tv" && inject) {
             const parsed = JSON.parse(responseText);
             parsed.unshift(fake_cast_server_resource);
             return JSON.stringify(parsed);


### PR DESCRIPTION
Plex seems to have updated the url used for when receiving information about clients. This pull request updates the url checked from "plex.tv" to "clients.plex.tv".

I haven't personally tested this elsewhere except for on my own Plex instance after I noticed the local connection script suddenly stopped working. 